### PR TITLE
Ability to add additional options

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 const async = require('async')
 const Base = require('bfx-facs-base')
 const FastifyAuth = require('@fastify/oauth2')
-const crypto = require('crypto')
 
 const SUPPORTED_AUTHS = ['google']
 
@@ -35,7 +34,7 @@ class HttpdAuthFacility extends Base {
     return specs
   }
 
-  injection () {
+  injection (opts = {}) {
     const creds = this.conf.credentials
     const specs = this.getSpecs(this.conf.method)
 
@@ -49,23 +48,7 @@ class HttpdAuthFacility extends Base {
       startRedirectPath: specs.startRedirectPath,
       callbackUri: specs.callbackUri,
       callbackUriParams: specs.callbackUriParams,
-      generateStateFunction: (request) => {
-        const statePayload = {
-          ...request.query,
-          csfr_token: crypto.randomBytes(8).toString('hex')
-        }
-
-        return Buffer.from(JSON.stringify(statePayload)).toString('base64url')
-      },
-      checkStateFunction: function (request, callback) {
-        const stateCookie = request.cookies['oauth2-redirect-state']
-
-        if (stateCookie && request.query.state === stateCookie) {
-          callback()
-          return
-        }
-        callback(new Error('ERR_INVALID_STATE'))
-      }
+      ...opts
     }]
   }
 


### PR DESCRIPTION
## Changes

- Added optional `opts` parameter to the `injection` function to support extra oauth2 setup params
- Required to allow custom state function on oauth2 request

## Notes

- Tested with and without `opts` to ensure existing behavior is unchanged